### PR TITLE
add prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 vllm_emulator/logs/
+vegeta
+
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/vllm_emulator/metrics.py
+++ b/vllm_emulator/metrics.py
@@ -1,0 +1,19 @@
+import prometheus_client
+from typing import List
+
+class Metrics:
+
+    def __init__(self, labelnames: List[str]):
+        self.gauge_scheduler_running = prometheus_client.Gauge(
+            name="vllm:num_requests_running",
+            documentation="Number of requests currently running on GPU.",
+            labelnames=labelnames)
+        self.gauge_scheduler_waiting = prometheus_client.Gauge(
+            name="vllm:num_requests_waiting",
+            documentation="Number of requests waiting to be processed.",
+            labelnames=labelnames)
+        #   KV Cache Usage in %
+        self.gauge_gpu_cache_usage = prometheus_client.Gauge(
+            name="vllm:gpu_cache_usage_perc",
+            documentation="GPU KV-cache usage. 1 means 100 percent usage.",
+            labelnames=labelnames)

--- a/vllm_emulator/requirements.txt
+++ b/vllm_emulator/requirements.txt
@@ -1,2 +1,4 @@
 fastapi[standard]
 openai
+prometheus_client
+pydantic-settings

--- a/vllm_emulator/server.py
+++ b/vllm_emulator/server.py
@@ -2,31 +2,46 @@
 
 import time
 import datetime
-import threading
+import re
+import asyncio
 
 from fastapi import FastAPI
 from typing import List, Optional
 from pydantic import BaseModel
+from contextlib import asynccontextmanager
+from prometheus_client import make_asgi_app
+from starlette.routing import Mount
 
-import asyncio
 
 ############################################  SETUP vLLM Emulator #####################################################
 
 from vllm_model import *
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    # Name or path of the huggingface model to use
+    model: str = "default"
+    # Time for one decode run in ms (inter-token latency) #TODO: Assumed independent of batch size or no of tokens generated
+    decode_time: int = DECODE_TIME
+    # Model size in MB
+    model_size: int = 25000
+    # KVCache size for one token in MB
+    kvc_per_token: int = KVC_PER_TOKEN
 
 
-clock = Clock(start_time = 0, step_time = DECODE_TIME)
-model = Model(model_id = 1, model_size = 25000, kvcache_per_token = KVC_PER_TOKEN)
-gpu   = Device(device_id = 1, net_memory = M, useable_ratio = 0.8)
+settings = Settings()
 
-vllmi = vLLM( device=gpu, clock=clock, model=model)
+clock = Clock(start_time = 0, step_time = settings.decode_time)
+model = Model(model_name = settings.model, model_size = settings.model_size, kvcache_per_token = settings.kvc_per_token)
+
+labels=dict(model_name=model)
+metrics = Metrics(labelnames=labels) # register metrics
+
+gpu   = Device(device_id = 1, net_memory = M, metrics = metrics, model_name = settings.model, useable_ratio = 0.8)
+
+vllmi = vLLM( device=gpu, clock=clock, model=model, metrics=metrics)
 load  = Load( avg_generated_len = 100, distribution = 'uniform')
 
-## Start as vLLM
-## Note: vllm emulator's run() is currently just a while loop. So not mkaing it a thread will deadlock the server.py
-vllm_thread = threading.Thread(target=vllmi.run)
-vllm_thread.start()
-## TODO: chat_completions() modifies the finished_queue. Havent checked thread safety of this setup
 
 ######################################################################################################################
 
@@ -42,18 +57,20 @@ class ChatCompletionRequest(BaseModel):
     temperature: Optional[float] = 0.1
     stream: Optional[bool] = False
 
-app = FastAPI(title="OpenAI-compatible API")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+  vllmTask = asyncio.create_task(vllmi.run())
+  print("Starting vLLM")
+  yield
+  vllmTask.cancel()
+  print("vLLM stopped")
+
+app = FastAPI(title="OpenAI-compatible API", lifespan=lifespan)
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: ChatCompletionRequest):
-
-    ## https://stackoverflow.com/questions/76913406/how-allow-fastapi-to-handle-multiple-requests-at-the-same-time
-    ## Async can't have simple sleep function, else will block the server
-    async def sleep_async(rid):
-        await asyncio.sleep(0.2)
-        print(f"Waiting for completion {rid}")
-
-
     input_seq = request.messages[-1].content
 
     input_len  = len(input_seq)
@@ -62,15 +79,8 @@ async def chat_completions(request: ChatCompletionRequest):
     req_id = now.strftime("%Y-%m-%dT%H:%M:%S-") + str(random.randint(0,100))
 
     reqi   = RequestElement(req_id=req_id, input_token_length=input_len, output_token_length=output_len)
-    vllmi.add_new_request(reqi)
 
-
-    complete = False
-    while not complete:
-       print(f"Waiting for completion {req_id}")
-       complete = vllmi.remove_finished_request(reqi)
-       await asyncio.sleep(0.5)                               #TODO: Sleep spinning to check very bad! Replace
-
+    await vllmi.add_new_request_wait(reqi)
 
     if request.messages and request.messages[0].role == 'user':
       resp_content = f"Request stats: arrival time = {reqi.arrival_time}, completion time = {reqi.completion_time}, ttft = {reqi.ttft_met_time}, input_token_len = {reqi.InputTokenLength}, output_token_len = {reqi.token_len}"
@@ -84,6 +94,17 @@ async def chat_completions(request: ChatCompletionRequest):
         "created": int(time.time()),
         "model": request.model,
         "choices": [{
+            "index" : 0,
             "message": ChatMessage(role="assistant", content=resp_content)
-        }]
+        }],
+        "usage": {
+            "prompt_tokens": reqi.InputTokenLength,
+            "completion_tokens": reqi.token_len,
+        }
     }
+
+# Add prometheus asgi middleware to route /metrics requests
+metrics_app = make_asgi_app()
+route = Mount("/metrics", metrics_app)
+route.path_regex = re.compile('^/metrics(?P<path>.*)$') # see https://github.com/prometheus/client_python/issues/1016#issuecomment-2088243791
+app.routes.append(route)


### PR DESCRIPTION
The PR does the following:
- it adds a new `/metrics` endpoint exposing a subset of vLLM metrics.
- it replaces polling for request completion by an asyncio event.  
- it starts the vLLM emulator as an async task instead of a thread.
- it prints stats every 2s to reduce logging.
- some parameters can now be specified externally through environment variables